### PR TITLE
Merge the wrapper class to Millepede from python into Millepede branch

### DIFF
--- a/charmdet/BoxLinkDef.h
+++ b/charmdet/BoxLinkDef.h
@@ -27,6 +27,7 @@
 #pragma link C++ class ReProcessAbsorber+;
 #pragma link C++ class RPCTrack+;
 #pragma link C++ class MufluxReco+;
+#pragma link C++ class MillepedeCaller+;
 
 #endif
 

--- a/charmdet/CMakeLists.txt
+++ b/charmdet/CMakeLists.txt
@@ -9,6 +9,7 @@ ${CMAKE_SOURCE_DIR}/charmdet
 ${CMAKE_SOURCE_DIR}/online
 ${CMAKE_SOURCE_DIR}/genfit/core/include
 ${CMAKE_SOURCE_DIR}/genfit/trackReps/include
+${CMAKE_SOURCE_DIR}/millepede
 ${ROOT_INCLUDE_DIR}
 )
 

--- a/charmdet/CMakeLists.txt
+++ b/charmdet/CMakeLists.txt
@@ -55,6 +55,6 @@ MillepedeCaller.cxx
 Set(HEADERS )
 Set(LINKDEF BoxLinkDef.h)
 Set(LIBRARY_NAME charmdet)
-Set(DEPENDENCIES Base ShipData GeoBase ParBase Geom Core genfit millepde)
+Set(DEPENDENCIES Base ShipData GeoBase ParBase Geom Core genfit millepede)
 
 GENERATE_LIBRARY()

--- a/charmdet/CMakeLists.txt
+++ b/charmdet/CMakeLists.txt
@@ -48,11 +48,12 @@ ShipPixelHit.cxx
 ReProcessAbsorber.cxx
 RPCTrack.cxx
 MufluxReco.cxx
+MillepedeCaller.cxx
 )
 
 Set(HEADERS )
 Set(LINKDEF BoxLinkDef.h)
 Set(LIBRARY_NAME charmdet)
-Set(DEPENDENCIES Base ShipData GeoBase ParBase Geom Core genfit)
+Set(DEPENDENCIES Base ShipData GeoBase ParBase Geom Core genfit millepde)
 
 GENERATE_LIBRARY()

--- a/charmdet/MillepedeCaller.cxx
+++ b/charmdet/MillepedeCaller.cxx
@@ -1,14 +1,62 @@
 #include "MillepedeCaller.h"
 #include <iostream>
 
+
+/**
+ * Constructor. Initializes the wrapper to the Mille class. All paramaters of this constructor
+ * are passed to the constructor of the Mille class.
+ *
+ * @brief Constructor
+ *
+ * @author Stefan Bieschke
+ * @date Apr 9, 2019
+ * @version 1.0
+ *
+ * @param outFileName string containing the filename written by mille function.
+ * @param asBinary Flag that states if file should be written as binary
+ * @param writeZero Flag that states if zero values should be kept or not
+ */
 MillepedeCaller::MillepedeCaller(const char *outFileName, bool asBinary, bool writeZero)
 : mille(outFileName, asBinary, writeZero)
 {
 
 }
 
+/**
+ * Default destructor. Tears down the object
+ *
+ * @brief Destructor
+ */
 MillepedeCaller::~MillepedeCaller()
 {
-	// TODO Auto-generated destructor stub
+
 }
 
+/**
+ * Call the mille function of the Mille object contained in this class. For a documentation of the parameters, see the Millepede documentation at:
+ * http://www.desy.de/~kleinwrt/MP2/doc/html/draftman_page.html
+ *
+ * @brief Mille caller
+ *
+ * @author Stefan Bieschke
+ * @date May 9, 2019
+ * @version 1.0
+ *
+ * @param n_local_derivatives Number of local derivatives.
+ * @param local_derivatives Pointer to values of the local derivatives. Array of floats as long as n_local_derivatives states.
+ * @param n_global_derivatives Number of global derivatives.
+ * @param global_derivatives Pointer to values of the global derivatives. Array of floats as long as n_global_derivatives states.
+ * @param label Array of unique labels to identify global parameters. This must be as long as n_global_derivatives states.
+ * @param measured_residual Residual of the hit for that mille is called.
+ * @param sigma Sigma of this hit.
+ */
+void MillepedeCaller::call_mille(int n_local_derivatives,
+					const float *local_derivatives,
+					int n_global_derivatives,
+					const float *global_derivatives,
+					const int *label,
+					float measured_residual,
+					float sigma)
+{
+
+}

--- a/charmdet/MillepedeCaller.cxx
+++ b/charmdet/MillepedeCaller.cxx
@@ -1,0 +1,14 @@
+#include "MillepedeCaller.h"
+#include <iostream>
+
+MillepedeCaller::MillepedeCaller(const char *outFileName, bool asBinary, bool writeZero)
+: mille(outFileName, asBinary, writeZero)
+{
+
+}
+
+MillepedeCaller::~MillepedeCaller()
+{
+	// TODO Auto-generated destructor stub
+}
+

--- a/charmdet/MillepedeCaller.cxx
+++ b/charmdet/MillepedeCaller.cxx
@@ -58,5 +58,5 @@ void MillepedeCaller::call_mille(int n_local_derivatives,
 					float measured_residual,
 					float sigma)
 {
-
+	mille.mille(n_local_derivatives,local_derivatives,n_global_derivatives,global_derivatives,label,measured_residual,sigma);
 }

--- a/charmdet/MillepedeCaller.h
+++ b/charmdet/MillepedeCaller.h
@@ -2,7 +2,7 @@
 #define CHARMDET_MILLEPEDECALLER_H_
 
 #include "TObject.h"
-#include "Mille.h
+#include "Mille.h"
 
 /**
  * A class for wrapping the millepede function call such that it can be called from

--- a/charmdet/MillepedeCaller.h
+++ b/charmdet/MillepedeCaller.h
@@ -1,0 +1,25 @@
+#ifndef CHARMDET_MILLEPEDECALLER_H_
+#define CHARMDET_MILLEPEDECALLER_H_
+
+#include "TObject.h"
+#include "Mille.h
+
+/**
+ * A class for wrapping the millepede function call such that it can be called from
+ * within a python script
+ *
+ * @author Stefan Bieschke
+ * @date Apr. 9, 2019
+ */
+class MillepedeCaller: public TObject
+{
+public:
+	MillepedeCaller(const char *outFileName, bool asBinary = true, bool writeZero = false);
+	~MillepedeCaller();
+	ClassDef(MillepedeCaller,1);
+
+private:
+	Mille mille;
+};
+
+#endif /* CHARMDET_MILLEPEDECALLER_H_ */

--- a/charmdet/MillepedeCaller.h
+++ b/charmdet/MillepedeCaller.h
@@ -16,6 +16,15 @@ class MillepedeCaller: public TObject
 public:
 	MillepedeCaller(const char *outFileName, bool asBinary = true, bool writeZero = false);
 	~MillepedeCaller();
+
+	void call_mille(int n_local_derivatives,
+					const float *local_derivatives,
+					int n_global_derivatives,
+					const float *global_derivatives,
+					const int *label,
+					float measured_residual,
+					float sigma);
+
 	ClassDef(MillepedeCaller,1);
 
 private:


### PR DESCRIPTION
# Contents
This contains a class MillepedeCaller written in c++ which inherits from ROOTs TObject as well as linkDefs for a ROOT dictionary and CMake implementation. 
Tested to be callable from within python.