### PR TITLE
Implementation of most functions needed to perform a refit of tracks with GBL

### DIFF
--- a/charmdet/DtAlignment/DriftTube.py
+++ b/charmdet/DtAlignment/DriftTube.py
@@ -40,7 +40,7 @@ class DriftTube(DetElement):
         
         #TODO: Read length from TGeo
         if(int(detId / 10000000) < 3):
-            self._length = 100 * u.cm
+            self._length = 110 * u.cm
         else:
             self._length = 160 * u.cm
             

--- a/charmdet/DtAlignment/utils/utils.py
+++ b/charmdet/DtAlignment/utils/utils.py
@@ -133,12 +133,12 @@ def distance_to_wire(tube,mom=None,pos=None):
     Returns
     -------
     float
-        Closest distance between track and wire in mm
+        Closest distance between track and wire
     """
     vtop,vbot = tube.wire_end_positions()    
     normal_vector = mom.Cross(vtop-vbot)
     vec_any_two_points = vbot - pos #a vector from any point on one of the straight lines to any point on the other straight
-    distance = (abs(vec_any_two_points.Dot(normal_vector)) / normal_vector.Mag()) * u.mm
+    distance = (abs(vec_any_two_points.Dot(normal_vector)) / normal_vector.Mag())
 
     return distance
 
@@ -193,9 +193,8 @@ def measurement_vector(tube,mom,pos):
     PCA_on_track = TVector3(pos + result[0] * mom)
     PCA_on_wire = TVector3(vbot + result[1] * wire_dir)
     
-    return TVector3(u.mm * (PCA_on_track - PCA_on_wire))
+    return TVector3(PCA_on_track - PCA_on_wire)
     
-        
 
 def calculate_residuals(track,dtmodules,module_residuals):
     """ Calculates the residuals for a given track and returns these in a dictionary
@@ -242,11 +241,6 @@ def calculate_residuals(track,dtmodules,module_residuals):
         
         # 5.) Calculate distance of track to wire
         dist = distance_to_wire(tube, mom, pos)
-        """
-        Testing for consistency
-        """
-        vec_between_PCA = measurement_vector(tube, mom, pos)
-        print("Hit: {}\tdist: {}\t Abs(vec): {}".format(i,dist,vec_between_PCA.Mag()))
         # 6.) Calculate residual and append to correct entry in dictionary
         residual = dist - rt_dist
         module_residuals[module_id['module']].append(residual)

--- a/charmdet/MillepedeCaller.cxx
+++ b/charmdet/MillepedeCaller.cxx
@@ -63,27 +63,85 @@ void MillepedeCaller::call_mille(int n_local_derivatives,
 	mille.mille(n_local_derivatives,local_derivatives,n_global_derivatives,global_derivatives,label,measured_residual,sigma);
 }
 
-//TODO document
-vector<gbl::GblPoint> MillepedeCaller::list_hits(const genfit::Track& track) const
+/**
+ * List the hits used to fit the seed track from a fit predecessing the GBL fit as a @c std::vector<gbl::GblPoint>. The GblPoint objects will
+ * also contain measurements after the call of this method. The GBL points are ordered by arclength, which is the distance on the track between
+ * two consecutive hits.
+ *
+ * @brief List hits from seed track as vector<GblPoint>
+ *
+ * @author Stefan Bieschke
+ * @date Aug. 06, 2019
+ * @version 1.0
+ *
+ * @param track Seed track, in this case genfit::Track from Kalman fitter
+ *
+ * @return std::vector<gbl::GblPoint> containing the hits ordered by arclen with measurement added
+ */
+vector<gbl::GblPoint> MillepedeCaller::list_hits(const genfit::Track* track) const
 {
-	vector<gbl::GblPoint> result = {};
+	std::vector<gbl::GblPoint> result = {};
 
-	size_t n_points = track.getNumPointsWithMeasurement();
-	vector<genfit::TrackPoint* > points = track.getPointsWithMeasurement();
+	vector<genfit::TrackPoint* > points = track->getPointsWithMeasurement();
+	size_t n_points = points.size();
 
-	multimap<double,TMatrixD*> jacobians_with_arclen = jacobians_with_arclength(track);
+	//define a struct to handle track parameters at a certain point as well as measurement and residual
+	struct hit_info
+	{
+		TMatrixD* jacobian;
+		double rt_measurement;
+		TVector3 closest_approach;
+	};
+
+	multimap<double,struct hit_info,less<double>> jacobians_with_arclen;
+
+	//#pragma omp parallel for
+	for(size_t i = 1; i < n_points; i++)
+	{
+		struct hit_info hit;
+		genfit::TrackPoint* point = points[i];
+		//get coords of upper and lower end of hit tube
+		genfit::AbsMeasurement* raw_measurement = point->getRawMeasurement();
+		TVectorD raw = raw_measurement->getRawHitCoords();
+		TVector3 vbot(raw[0],raw[1],raw[2]);
+		TVector3 vtop(raw[3],raw[4],raw[5]);
+		double measurement = raw[6]; //rt distance [cm]
+
+		TVector3 fit_pos = track->getFittedState(i).getPos();
+		TVector3 fit_mom = track->getFittedState(i).getMom();
+		TVector3 closest_approach = calc_shortest_distance(vtop,vbot,fit_pos,fit_mom);
+		pair<double,TMatrixD*> jacobian_with_arclen = single_jacobian_with_arclength(*track,i);
+
+		//hit struct seems to be copied correctly into multimap
+		hit.jacobian = jacobian_with_arclen.second;
+		hit.closest_approach = closest_approach;
+		hit.rt_measurement = measurement;
+		jacobians_with_arclen.insert(make_pair(jacobian_with_arclen.first,hit));
+	}
+	//TODO calculate GBLpoint for hit no. 0
 
 	for(auto it = jacobians_with_arclen.begin(); it != jacobians_with_arclen.end(); it++)
 	{
-		TMatrixD* jacobian = it->second;
+		TMatrixD* jacobian = it->second.jacobian;
+		//TODO test if the GblPoint constructor stores a copy so that original jacobian can be deleted
 		result.push_back(gbl::GblPoint(*jacobian));
+		TRotation rot = calc_rotation_of_vector(it->second.closest_approach);
+		TMatrixD rot_mat = rot_to_matrix(rot);
+		//TODO fix, fit not working
+		TVectorD rotated_residual(3);
+		rotated_residual[0] = it->second.closest_approach.Mag() - it->second.rt_measurement;
+		rotated_residual[1] = 0;
+		rotated_residual[2] = 0;
+		TVectorD precision(rotated_residual);
+		precision[0] = 250 * 1e-4; //250 um in cm
+		result.back().addMeasurement(rot_mat,rotated_residual,precision);
 	}
 
 	return result;
 }
 
 
-
+//TODO implement
 const int* MillepedeCaller::labels() const
 {
 	return new int[100];
@@ -109,15 +167,16 @@ const int* MillepedeCaller::labels() const
  *
  * @warning Requires hit_id_1 = hit_id_2 - 1
  * @warning Requires hit_id_1 < track.getNumPointsWithMeasurement() && hit_id_2 < track.getNumPointsWithMeasurement()
+ * @warning Heap object without auto deletion
  */
-TMatrixD* MillepedeCaller::calc_jacobian(const genfit::Track& track, const unsigned int hit_id_1, const unsigned int hit_id_2) const
+TMatrixD* MillepedeCaller::calc_jacobian(const genfit::Track* track, const unsigned int hit_id_1, const unsigned int hit_id_2) const
 {
 	TMatrixD* jacobian = new TMatrixD(5,5);
 
 	// 1.) init unity matrix
-	for(unsigned int row = 0; row < jacobian->GetNrows(); row++)
+	for(uint8_t row = 0; row < jacobian->GetNrows(); row++)
 	{
-		for(unsigned int col = 0; col < jacobian->GetNcols(); col++)
+		for(uint8_t col = 0; col < jacobian->GetNcols(); col++)
 		{
 			if(row == col)
 			{
@@ -133,8 +192,8 @@ TMatrixD* MillepedeCaller::calc_jacobian(const genfit::Track& track, const unsig
 
 	//2.) enter non-zero partial differentials
 	//2.1) get the two points on track where reconstruction happened
-	genfit::MeasuredStateOnPlane state_at_id_1 = track.getFittedState(hit_id_1);
-	genfit::MeasuredStateOnPlane state_at_id_2 = track.getFittedState(hit_id_2);
+	genfit::MeasuredStateOnPlane state_at_id_1 = track->getFittedState(hit_id_1);
+	genfit::MeasuredStateOnPlane state_at_id_2 = track->getFittedState(hit_id_2);
 
 	TVector3 pos1 = state_at_id_1.getPos();
 	TVector3 pos2 = state_at_id_2.getPos();
@@ -146,9 +205,6 @@ TMatrixD* MillepedeCaller::calc_jacobian(const genfit::Track& track, const unsig
 	(*jacobian)[3][1] = dx;
 	(*jacobian)[4][2] = dy;
 
-	//debugging output
-	cout << " ------- Jacobian before passing on ----------" << endl;
-	jacobian->Print();
 
 	return jacobian;
 }
@@ -158,47 +214,145 @@ TMatrixD* MillepedeCaller::calc_jacobian(const genfit::Track& track, const unsig
 /**
  *
  */
-multimap<double,TMatrixD*> MillepedeCaller::jacobians_with_arclength(const genfit::Track& track) const
+multimap<double,TMatrixD*> MillepedeCaller::jacobians_with_arclength(const genfit::Track* track) const
 {
 	multimap<double,TMatrixD*,less<double>> result;
 
-	unsigned int n_hits = track.getNumPointsWithMeasurement();
+	unsigned int n_hits = track->getNumPointsWithMeasurement();
 
-	//debugging output
-	cout << " ------- Jacobian ordering ----------" << endl;
-	cout << "Ordering jacobians for " << n_hits << " by arclength" << endl;
 
+	//TODO add unity matrix as first entry
 	for (unsigned int hit_id = 1; hit_id < n_hits; hit_id++)
 	{
-		//debugging output
-		cout << "Hit: " << hit_id << endl;
-		//calculate length of the track between the two hits (in GBL terms arc length)
-		TVector3 fitted_pos_1 = track.getFittedState(hit_id - 1).getPos();
-		TVector3 fitted_pos_2 = track.getFittedState(hit_id).getPos();
-		TVector3 between_hits = fitted_pos_2 - fitted_pos_1;
-		double distance = between_hits.Mag();
-
-		cout << "Arc length: " << distance << endl;
-
-		TMatrixD* jacobian = calc_jacobian(track, hit_id - 1, hit_id);
-
-		cout << "Jacbian after passing:" << endl;
-		jacobian->Print();
-		result.insert(make_pair(distance, jacobian));
+		result.insert(single_jacobian_with_arclength(*track,hit_id));
 	}
-
-	//debugging output
-	cout << "-------- Whole map before passing ----------" << endl;
-	for(auto it = result.begin(); it != result.end(); ++it)
-	{
-		double arclen = it->first;
-		TMatrixD* mat = it->second;
-		cout << "Arclen: " << arclen << endl;
-		mat->Print();
-		cout << "END OF HIT" << endl;
-	}
-
 
 	//return a copy of the map. Since it's small it is probably better than handling memory and matrices are stored as pointers to heap
+	return result;
+}
+
+/**
+ * Calculate the jacobian matrix for the transport of track parameters from the previous hit to a hit labelled by @c hit_id. Alongside
+ * the jacobian matrix, an arclength is calculated, which is the distance on the track between the previous hit and the hit specified by
+ * @c hit_id. Note that as the transport of parameters from the previous hit is calculated, the parameter @c hit_id is required to be
+ * greater than zero. See the requirements below for more details.
+ * The result is returned as std::pair<double,TMatrixD*>. The TMatrixD* pointer points to heap memory holding the 5x5 jacobian matrix.
+ * For more info on the jacobian see the documentation of the method
+ * @c calc_jacobian(const genfit::Track* track, const unsigned int hit_id_1, const unsigned int hit_id_2) const.
+ *
+ * @brief Calculate a single pair of jacobian with arclength for a given @c hit_id
+ *
+ * @author Stefan Bieschke
+ * @date Aug. 06, 2019
+ * @version 1.0
+ *
+ * @param track Seed track from a fit predecessing the GBL refit, e.g the genfit Kalman fitter
+ * @param hit_id ID (number) of the hit for that the pair shall be computed. See requirements below
+ *
+ * @require 0 < hit_id < track.getNumPointsWithMeasurement()
+ *
+ * @return std::pair<double,TMatrixD*> containing the the arclength and the jacobian matrix
+ *
+ * @warning TMatrixD* is heap memory and undeleted. Must be deleted by caller when no longer needed.
+ */
+pair<double,TMatrixD*> MillepedeCaller::single_jacobian_with_arclength(const genfit::Track& track, const unsigned int hit_id) const
+{
+	TVector3 fitted_pos_1 = track.getFittedState(hit_id - 1).getPos();
+	TVector3 fitted_pos_2 = track.getFittedState(hit_id).getPos();
+	TVector3 between_hits = fitted_pos_2 - fitted_pos_1;
+
+	double distance = between_hits.Mag();
+
+	TMatrixD* jacobian = calc_jacobian(&track, hit_id - 1, hit_id);
+
+	return make_pair(distance, jacobian);
+}
+
+//TODO document
+/**
+ *
+ */
+double MillepedeCaller::perform_GBL_refit(const genfit::Track& track) const
+{
+	vector<gbl::GblPoint> points = list_hits(&track);
+	gbl::GblTrajectory traj(points);
+
+	int rc, ndf;
+	double chi2, lostWeight;
+
+	cout << "------------performing refit--------------" << endl;
+	cout << "Seed track chi2: " << track.getFitStatus()->getChi2() << " Ndf: " << track.getFitStatus()->getNdf() << endl;
+
+	rc = traj.fit(chi2,ndf,lostWeight);
+	cout << "Refit chi2: " << chi2 << " Ndf: " << ndf << endl;
+
+	return chi2;
+}
+
+//TODO document
+//Reimplementation of python function
+/**
+ *
+ */
+TVector3 MillepedeCaller::calc_shortest_distance(const TVector3& wire_top, const TVector3& wire_bot, const TVector3& track_pos, const TVector3& track_mom) const
+{
+	TVector3 wire_dir = wire_top - wire_bot;
+
+	TVector3 plane_pos = track_pos - wire_bot;
+	TVector3 plane_dir_1(track_mom);
+	TVector3 plane_dir_2(-1 * wire_dir);
+
+	TVectorD const_vector(2);
+	TMatrixD coeff_matrix(2,2);
+
+	const_vector[0] = -(plane_pos.Dot(track_mom));
+	const_vector[1] = -(plane_pos.Dot(wire_dir));
+
+	coeff_matrix[0][0] = plane_dir_1.Dot(track_mom);
+	coeff_matrix[0][1] = plane_dir_2.Dot(track_mom);
+	coeff_matrix[1][0] = plane_dir_1.Dot(wire_dir);
+	coeff_matrix[1][1] = plane_dir_2.Dot(wire_dir);
+
+	TDecompLU solvable_matrix(coeff_matrix);
+	TVectorD result(const_vector);
+	int rc = solvable_matrix.Solve(result);
+
+	TVector3 PCA_on_track(track_pos + result[0] * track_mom);
+	TVector3 PCA_on_wire(wire_bot + result[1] * wire_dir);
+
+	return TVector3(PCA_on_track - PCA_on_wire);
+}
+
+/**
+ * Calculate the rotation matrix in a way such that a given vector v is the x-axis of the rotated coordinate frame.
+ *
+ * @brief Rotation of a given vector in lab frame so that it is new x axis
+ *
+ * @author Stefan Bieschke
+ * @date Aug. 09, 2019
+ * @version 1.0
+ *
+ * @param v TVector3 that is meant to be the new x axis of the rotated coordinate frame
+ *
+ * @return TRotation containing the rotation matrix
+ */
+TRotation MillepedeCaller::calc_rotation_of_vector(const TVector3& v) const
+{
+	TRotation rot;
+	rot.SetXAxis(v);
+
+	return rot;
+}
+
+TMatrixD MillepedeCaller::rot_to_matrix(const TRotation& rot) const
+{
+	TMatrixD result(3,3);
+	for(uint8_t i = 0; i < 3; i++)
+	{
+		for(uint8_t j = 0; j < 3; j++)
+		{
+			result[i][j] = rot[i][j];
+		}
+	}
 	return result;
 }

--- a/charmdet/MillepedeCaller.h
+++ b/charmdet/MillepedeCaller.h
@@ -10,8 +10,26 @@
 #include "MilleBinary.h"
 #include "Track.h"
 #include "TMatrixD.h"
+#include "TVectorD.h"
 #include <map>
 #include "TVector3.h"
+#include "TDecompLU.h"
+#include "TRotation.h"
+#include <cstdint>
+
+//class JacobianWithArclen
+//{
+//public:
+//	JacobianWithArclen(TMatrixD* jacobian, double arclen);
+//	~JacobianWithArclen();
+//
+//	TMatrixD* get_jacobian();
+//	double get_arclen();
+//
+//private:
+//	TMatrixD* m_jacobian;
+//	double m_arclen;
+//};
 
 /**
  * A class for wrapping the millepede function call such that it can be called from
@@ -20,7 +38,7 @@
  * @author Stefan Bieschke
  * @date Apr. 9, 2019
  */
-class MillepedeCaller: public TObject
+class MillepedeCaller//: public TObject
 {
 public:
 	MillepedeCaller(const char *outFileName, bool asBinary = true, bool writeZero = false);
@@ -34,17 +52,22 @@ public:
 					float measured_residual,
 					float sigma);
 
-	std::vector<gbl::GblPoint> list_hits(const genfit::Track& track) const;
 	const int* labels() const;
+	double perform_GBL_refit(const genfit::Track& track) const;
 
-	ClassDef(MillepedeCaller,2);
+	ClassDef(MillepedeCaller,3);
 
 private:
 	Mille mille;
 
 	//helper methods
-	TMatrixD* calc_jacobian(const genfit::Track& track, const unsigned int hit_id_1, const unsigned int hit_id_2) const;
-	std::multimap<double,TMatrixD*> jacobians_with_arclength(const genfit::Track& track) const;
+	std::vector<gbl::GblPoint> list_hits(const genfit::Track* track) const;
+	TMatrixD* calc_jacobian(const genfit::Track* track, const unsigned int hit_id_1, const unsigned int hit_id_2) const;
+	std::pair<double,TMatrixD*> single_jacobian_with_arclength(const genfit::Track& track, const unsigned int hit_id) const;
+	std::multimap<double,TMatrixD*> jacobians_with_arclength(const genfit::Track* track) const;
+	TVector3 calc_shortest_distance(const TVector3& wire_top, const TVector3& wire_bot, const TVector3& track_pos, const TVector3& track_mom) const;
+	TRotation calc_rotation_of_vector(const TVector3& v) const;
+	TMatrixD rot_to_matrix(const TRotation& rot) const;
 };
 
 #endif /* CHARMDET_MILLEPEDECALLER_H_ */

--- a/charmdet/drifttubeMonitoring.py
+++ b/charmdet/drifttubeMonitoring.py
@@ -2786,6 +2786,9 @@ def plotBiasedResiduals(nEvent=-1,nTot=1000,PR=1,onlyPlotting=False,minP=3.):
  module_residuals = {}
  for key in dt_modules.keys():
   module_residuals[key] = []
+  
+  #debugging
+  milleCaller = ROOT.MillepedeCaller("test.milletest",True,True)
     
  if not onlyPlotting:
   if not h.has_key('hitMapsX'): plotHitMaps()
@@ -2806,6 +2809,7 @@ def plotBiasedResiduals(nEvent=-1,nTot=1000,PR=1,onlyPlotting=False,minP=3.):
   timerStats = {'fit':0,'analysis':0,'prepareTrack':0,'extrapTrack':0,'fillRes':0}
   for Nr in range(eventRange[0],eventRange[1]):
    getEvent(Nr)
+
    h['T0tmp'].Reset()
    if Nr%10000==0:   print "now at event",Nr,' of ',sTree.GetEntries(),sTree.GetCurrentFile().GetName(),time.ctime()
    if not findSimpleEvent(sTree): continue
@@ -2839,6 +2843,11 @@ def plotBiasedResiduals(nEvent=-1,nTot=1000,PR=1,onlyPlotting=False,minP=3.):
        rc = h['biasResTrackMom'].Fill(sta.getMomMag())
        timerStats['prepareTrack']+=timer.RealTime()
        timer.Start()
+       """
+       refit
+       """
+       print("Testing: Processing event number", Nr)
+       chi2_gbl = milleCaller.perform_GBL_refit(aTrack)
        """
        New calculation of residuals
        """


### PR DESCRIPTION
# included methods

- calculating the jacobian matrix of track parameter transport from one hit to another
- calculating the arclength on a track between two consecutive hits
- ordering jacobians by arclength between hits
- calculating the closest approach vector between track and sense wire
- calculating the rotation matrix for curvilinear measurements

# status of testing
- Mille binary created
- Refit not yet converging