### PR TITLE
Changed start of track extrapolation in an exceptional mode

### DIFF
--- a/charmdet/MufluxReco.cxx
+++ b/charmdet/MufluxReco.cxx
@@ -543,7 +543,7 @@ Double_t MufluxReco::extrapolateToPlane(genfit::Track* fT, Float_t z, TVector3& 
 					mom = fstate.getMom();
 				} catch (const genfit::Exception& e) {
 					auto CRep = fT->getCardinalRep();
-					auto point = fT->getPointWithMeasurementAndFitterInfo(1, CRep);
+					auto point = fT->getPointWithMeasurementAndFitterInfo(last_hit_id, CRep);
 					if(!point) {
 						return -1;
 					}


### PR DESCRIPTION
Changed the point from which a track extrapolation is performed to the last one in the list of hits instead of the second hit.

This implements https://github.com/ShipSoft/FairShip/pull/318#issuecomment-554744720