### PR TITLE
Toy MC for testing the GBL refit implemented

### DIFF
--- a/charmdet/MillepedeCaller.cxx
+++ b/charmdet/MillepedeCaller.cxx
@@ -21,7 +21,7 @@ using namespace std;
 MillepedeCaller::MillepedeCaller(const char *outFileName, bool asBinary, bool writeZero)
 : mille(outFileName, asBinary, writeZero)
 {
-	m_mersenne_twister = mt19937();
+	m_mersenne_twister = mt19937(19937);
 	m_gbl_mille_binary = new gbl::MilleBinary("debugging.mille_bin",true,2000);
 
 	m_tube_ids.resize(0);

--- a/charmdet/MillepedeCaller.cxx
+++ b/charmdet/MillepedeCaller.cxx
@@ -804,7 +804,7 @@ vector<pair<int,double>> MillepedeCaller::MC_gen_hits(const TVector3& start, con
 		MufluxSpectrometer::TubeEndPoints(element2.second, wire_end_top, wire_end_bottom);
 		double z2 = wire_end_bottom + ((wire_end_top - wire_end_bottom)* 0.5).Z();
 		return z1 < z2;
-		})
+		});
 
 	return result;
 }
@@ -818,7 +818,7 @@ TMatrixD* MillepedeCaller::calc_jacobian(const TVector3& PCA_1, const TVector3& 
 
 	//2.) enter non-zero partial differentials
 	//2.1) get the two points on track where reconstruction happened
-	double dz = PCA_2 - PCA_1;
+	double dz = PCA_2.Z() - PCA_1.Z();
 
 	//2.2) enter dx and dy to jacobian
 	(*jacobian)[3][1] = dz;

--- a/charmdet/MillepedeCaller.cxx
+++ b/charmdet/MillepedeCaller.cxx
@@ -449,7 +449,7 @@ double MillepedeCaller::MC_GBL_refit(unsigned int n_tracks)
 	for(int i = 0; i < tracks.size(); ++i)
 	{
 		auto track = tracks[i];
-		vector<gbl::GblPoint> hitlist = MC_list_hits(track,i);
+		vector<gbl::GblPoint> hitlist = MC_list_hits(track,fitted);
 		if(hitlist.size() < 24)
 		{
 			continue;

--- a/charmdet/MillepedeCaller.cxx
+++ b/charmdet/MillepedeCaller.cxx
@@ -445,16 +445,23 @@ double MillepedeCaller::MC_GBL_refit(unsigned int n_tracks)
 		cout << "(" << pos[0] << "," << pos[1] << "," << pos[2] << ") + (" << mom[0] << "," << mom[1] << "," << mom[2] << ")" << endl;
 	}
 
+	unsigned int fitted = 0;
 	for(int i = 0; i < tracks.size(); ++i)
 	{
 		auto track = tracks[i];
 		vector<gbl::GblPoint> hitlist = MC_list_hits(track,i);
+		if(hitlist.size() < 24)
+		{
+			continue;
+		}
 		gbl::GblTrajectory traj(hitlist, false);
 		traj.milleOut(*m_gbl_mille_binary);
 		traj.fit(chi2, ndf, lostweight);
 		cout << "MC chi2: " << chi2 << " Ndf: " << ndf << endl;
 		cout << "Prob: " << TMath::Prob(chi2,ndf) << endl;
+		++fitted;
 	}
+	cout << "Fitted " << fitted << " out of " << n_tracks << " tracks." << endl;
 
 	return 0.0;
 }
@@ -706,6 +713,10 @@ vector<gbl::GblPoint> MillepedeCaller::MC_list_hits(const vector<TVector3>& mc_t
 	normal_distribution<double> gaussian_smear(0,350e-4); //mean 0, sigma 350um in cm
 
 	vector<pair<int,double>> hits = MC_gen_hits(mc_track_model[0], mc_track_model[1]);
+	if(hits.size() < 24)
+	{
+		return {};
+	}
 
 	ofstream trackhits("hits.ascii",ios::app);
 
@@ -775,7 +786,7 @@ vector<gbl::GblPoint> MillepedeCaller::MC_list_hits(const vector<TVector3>& mc_t
 		gbl_hits.back().addMeasurement(projection_matrix,rotated_residual,precision);
 		delete jacobian;
 	}
-	trackhits << endl:
+	trackhits << endl;
 	trackhits.close();
 
 	return gbl_hits;

--- a/charmdet/MillepedeCaller.cxx
+++ b/charmdet/MillepedeCaller.cxx
@@ -451,6 +451,7 @@ double MillepedeCaller::MC_GBL_refit(unsigned int n_tracks)
 		gbl::GblTrajectory traj(hitlist, false);
 		traj.fit(chi2, ndf, lostweight);
 		cout << "MC chi2: " << chi2 << " Ndf: " << ndf << endl;
+		cout << "Prob: " << TMath::Prob(chi2,ndf) << endl;
 	}
 
 	return 0.0;
@@ -743,7 +744,7 @@ vector<gbl::GblPoint> MillepedeCaller::MC_list_hits(const vector<TVector3>& mc_t
 	rotated_residual[0] = closest_approach.Mag() - (hits[0].second + smear);
 	rotated_residual[1] = 0;
 	TVectorD precision(rotated_residual);
-	precision[0] = 1.0 / (0.05 * 0.05); //1 mm, really bad resolution
+	precision[0] = 1.0 / (0.035 * 0.035); //1 mm, really bad resolution
 	gbl_hits.back().addMeasurement(projection_matrix,rotated_residual,precision);
 
 
@@ -762,7 +763,7 @@ vector<gbl::GblPoint> MillepedeCaller::MC_list_hits(const vector<TVector3>& mc_t
 		rotated_residual[0] = closest_approach.Mag() - (hits[i].second + smear);
 		rotated_residual[1] = 0;
 		TVectorD precision(rotated_residual);
-		precision[0] = 1.0 / (0.05 * 0.05); //1 mm, really bad resolution
+		precision[0] = 1.0 / (0.035 * 0.035); //1 mm, really bad resolution
 		gbl_hits.back().addMeasurement(projection_matrix,rotated_residual,precision);
 		delete jacobian;
 	}

--- a/charmdet/MillepedeCaller.cxx
+++ b/charmdet/MillepedeCaller.cxx
@@ -59,7 +59,15 @@ MillepedeCaller::MillepedeCaller(const char *outFileName, bool asBinary, bool wr
 			}
 		}
 	}
+
+	cout << "Generated detector IDs, printing:" << endl;
+	for(int id : m_tube_ids)
+	{
+		cout << id << endl;
+	}
 }
+
+
 
 /**
  * Default destructor. Tears down the object
@@ -427,6 +435,14 @@ double MillepedeCaller::MC_GBL_refit(unsigned int n_tracks)
 	for(unsigned int i = 0; i < n_tracks; ++i)
 	{
 		tracks[i] = MC_gen_track();
+	}
+
+	cout << tracks.size() <<" track generated. Printing:" << endl;
+	for(auto track : tracks)
+	{
+		TVector3 pos = track[0];
+		TVector3 mom = track[1];
+		cout << "(" << pos[0] << "," << pos[1] << "," << pos[2] << ") + (" << mom[0] << "," << mom[1] << "," << mom[2] << ")" << endl;
 	}
 
 	for(auto track : tracks)

--- a/charmdet/MillepedeCaller.cxx
+++ b/charmdet/MillepedeCaller.cxx
@@ -808,7 +808,12 @@ vector<pair<int,double>> MillepedeCaller::MC_gen_hits(const TVector3& start, con
 	//check distance to every tube
 	for(int id : m_tube_ids)
 	{
+		cout << "Decoding id" << id << endl;
 		MufluxSpectrometer::TubeEndPoints(id, wire_end_top, wire_end_bottom);
+		cout << "Top point: " << endl;
+		wire_end_top.Print();
+		cout << "Bottom point: " << endl;
+		wire_end_bottom.Print();
 		wire_to_track = calc_shortest_distance(wire_end_top, wire_end_bottom, start, direction, nullptr, nullptr);
 		if(wire_to_track.Mag() < 1.815)
 		{

--- a/charmdet/MillepedeCaller.cxx
+++ b/charmdet/MillepedeCaller.cxx
@@ -432,6 +432,7 @@ double MillepedeCaller::MC_GBL_refit(unsigned int n_tracks)
 	double chi2, lostweight;
 	int ndf;
 	vector<vector<TVector3>> tracks(n_tracks);
+	traj.milleOut(*m_gbl_mille_binary);
 	for(unsigned int i = 0; i < n_tracks; ++i)
 	{
 		tracks[i] = MC_gen_track();

--- a/charmdet/MillepedeCaller.cxx
+++ b/charmdet/MillepedeCaller.cxx
@@ -427,7 +427,7 @@ double MillepedeCaller::perform_GBL_refit(const genfit::Track& track) const
 		return -1;
 	}
 }
-double MillepedeCaller::MC_GBL_refit(unsigned int n_tracks, double smearing_sigma)
+double MillepedeCaller::MC_GBL_refit(unsigned int n_tracks, double smearing_sigma, unsigned int min_hits = 3)
 {
 	double chi2, lostweight;
 	int ndf;
@@ -449,8 +449,8 @@ double MillepedeCaller::MC_GBL_refit(unsigned int n_tracks, double smearing_sigm
 	for(int i = 0; i < tracks.size(); ++i)
 	{
 		auto track = tracks[i];
-		vector<gbl::GblPoint> hitlist = MC_list_hits(track,fitted,smearing_sigma);
-		if(hitlist.size() < 24)
+		vector<gbl::GblPoint> hitlist = MC_list_hits(track,fitted,smearing_sigma,min_hits);
+		if(hitlist.size() < min_hits)
 		{
 			continue;
 		}
@@ -707,13 +707,13 @@ void MillepedeCaller::print_seed_hits(const genfit::Track& track) const
 
 //TODO test projection matrix
 
-vector<gbl::GblPoint> MillepedeCaller::MC_list_hits(const vector<TVector3>& mc_track_model, int event_id, double smearing_sigma)
+vector<gbl::GblPoint> MillepedeCaller::MC_list_hits(const vector<TVector3>& mc_track_model, int event_id, double smearing_sigma, unsigned int min_hits)
 {
 	//apply gaussian smearing of measured hit
 	normal_distribution<double> gaussian_smear(0,smearing_sigma); //mean 0, sigma 350um in cm
 
 	vector<pair<int,double>> hits = MC_gen_hits(mc_track_model[0], mc_track_model[1]);
-	if(hits.size() < 24)
+	if(hits.size() < min_hits)
 	{
 		return {};
 	}

--- a/charmdet/MillepedeCaller.cxx
+++ b/charmdet/MillepedeCaller.cxx
@@ -774,7 +774,7 @@ vector<TVector3> MillepedeCaller::MC_gen_track() const
 	TVector3 beginning = TVector3(offset_x_beginning, offset_y_beginning, z_beginning);
 	TVector3 end = TVector3(offset_x_end, offset_y_end, z_end);
 	TVector3 direction = end - beginning;
-	vector<TVector3> result = {beginning, direction}
+	vector<TVector3> result = {beginning, direction};
 
 	return result;
 }
@@ -802,7 +802,7 @@ vector<pair<int,double>> MillepedeCaller::MC_gen_hits(const TVector3& start, con
 		MufluxSpectrometer::TubeEndPoints(element1.second, wire_end_top, wire_end_bottom);
 		double z1 = (wire_end_bottom + ((wire_end_top - wire_end_bottom)* 0.5)).Z();
 		MufluxSpectrometer::TubeEndPoints(element2.second, wire_end_top, wire_end_bottom);
-		double z2 = wire_end_bottom + ((wire_end_top - wire_end_bottom)* 0.5).Z();
+		double z2 = (wire_end_bottom + ((wire_end_top - wire_end_bottom)* 0.5)).Z();
 		return z1 < z2;
 		});
 

--- a/charmdet/MillepedeCaller.cxx
+++ b/charmdet/MillepedeCaller.cxx
@@ -419,7 +419,7 @@ double MillepedeCaller::perform_GBL_refit(const genfit::Track& track) const
 		return -1;
 	}
 }
-double MillepedeCaller::MC_GBL_refit(unsigned int n_tracks) const
+double MillepedeCaller::MC_GBL_refit(unsigned int n_tracks)
 {
 	double chi2, lostweight;
 	int ndf;
@@ -681,10 +681,10 @@ void MillepedeCaller::print_seed_hits(const genfit::Track& track) const
 
 //TODO test projection matrix
 
-vector<gbl::GblPoint> MillepedeCaller::MC_list_hits(const vector<TVector3>& mc_track_model) const
+vector<gbl::GblPoint> MillepedeCaller::MC_list_hits(const vector<TVector3>& mc_track_model)
 {
 	//apply gaussian smearing of measured hit
-	normal_distribution<double> gaussian_smear(0.0,350e-4); //mean 0, sigma 350um in cm
+	normal_distribution<double> gaussian_smear(0,350e-4); //mean 0, sigma 350um in cm
 
 	vector<pair<int,double>> hits = MC_gen_hits(mc_track_model[0], mc_track_model[1]);
 	vector<gbl::GblPoint> gbl_hits = {};
@@ -711,7 +711,8 @@ vector<gbl::GblPoint> MillepedeCaller::MC_list_hits(const vector<TVector3>& mc_t
 	TMatrixD rot_mat = rot_to_matrix(rot);
 	TMatrixD projection_matrix = calc_projection_matrix(fit_system_base_vectors,rot_mat);
 	TVectorD rotated_residual(2);
-	rotated_residual[0] = closest_approach.Mag() - (hits[0].second + gaussian_smear(m_mersenne_twister));
+	double smear = gaussian_smear(m_mersenne_twister);
+	rotated_residual[0] = closest_approach.Mag() - (hits[0].second + smear);
 	rotated_residual[1] = 0;
 	TVectorD precision(rotated_residual);
 	precision[0] = 1.0 / (0.05 * 0.05); //1 mm, really bad resolution
@@ -729,7 +730,8 @@ vector<gbl::GblPoint> MillepedeCaller::MC_list_hits(const vector<TVector3>& mc_t
 		TMatrixD rot_mat = rot_to_matrix(rot);
 		TMatrixD projection_matrix = calc_projection_matrix(fit_system_base_vectors,rot_mat);
 		TVectorD rotated_residual(2);
-		rotated_residual[0] = closest_approach.Mag() - (hits[i].second + gaussian_smear(m_mersenne_twister));
+		smear = gaussian_smear(m_mersenne_twister);
+		rotated_residual[0] = closest_approach.Mag() - (hits[i].second + smear);
 		rotated_residual[1] = 0;
 		TVectorD precision(rotated_residual);
 		precision[0] = 1.0 / (0.05 * 0.05); //1 mm, really bad resolution
@@ -740,7 +742,7 @@ vector<gbl::GblPoint> MillepedeCaller::MC_list_hits(const vector<TVector3>& mc_t
 	return gbl_hits;
 }
 
-vector<TVector3> MillepedeCaller::MC_gen_track() const
+vector<TVector3> MillepedeCaller::MC_gen_track()
 {
 	/*
 	 * Track locations uniformly distributed in front of first plane and in front of first plane of T4.
@@ -780,7 +782,7 @@ vector<TVector3> MillepedeCaller::MC_gen_track() const
 	return result;
 }
 
-vector<pair<int,double>> MillepedeCaller::MC_gen_hits(const TVector3& start, const TVector3& direction) const
+vector<pair<int,double>> MillepedeCaller::MC_gen_hits(const TVector3& start, const TVector3& direction)
 {
 	vector<pair<int,double>> result(0);
 	TVector3 wire_end_top;
@@ -810,7 +812,7 @@ vector<pair<int,double>> MillepedeCaller::MC_gen_hits(const TVector3& start, con
 	return result;
 }
 
-TMatrixD* MillepedeCaller::calc_jacobian(const TVector3& PCA_1, const TVector3& PCA_2) const
+TMatrixD* MillepedeCaller::calc_jacobian(const TVector3& PCA_1, const TVector3& PCA_2)
 {
 	TMatrixD* jacobian = new TMatrixD(5,5);
 

--- a/charmdet/MillepedeCaller.cxx
+++ b/charmdet/MillepedeCaller.cxx
@@ -686,7 +686,7 @@ vector<gbl::GblPoint> MillepedeCaller::MC_list_hits(const vector<TVector3>& mc_t
 	normal_distribution<double> gaussian_smear(0.0,350e-4); //mean 0, sigma 350um in cm
 
 	vector<pair<int,double>> hits = MC_gen_hits(mc_track_model[0], mc_track_model[1]);
-	vector<gbl::GblPoint> gbl_hits(0);
+	vector<gbl::GblPoint> gbl_hits = {};
 
 	TMatrixD fit_system_base_vectors(2,3);
 	fit_system_base_vectors.Zero();

--- a/charmdet/MillepedeCaller.cxx
+++ b/charmdet/MillepedeCaller.cxx
@@ -432,7 +432,6 @@ double MillepedeCaller::MC_GBL_refit(unsigned int n_tracks)
 	double chi2, lostweight;
 	int ndf;
 	vector<vector<TVector3>> tracks(n_tracks);
-	traj.milleOut(*m_gbl_mille_binary);
 	for(unsigned int i = 0; i < n_tracks; ++i)
 	{
 		tracks[i] = MC_gen_track();
@@ -450,6 +449,7 @@ double MillepedeCaller::MC_GBL_refit(unsigned int n_tracks)
 	{
 		vector<gbl::GblPoint> hitlist = MC_list_hits(track);
 		gbl::GblTrajectory traj(hitlist, false);
+		traj.milleOut(*m_gbl_mille_binary);
 		traj.fit(chi2, ndf, lostweight);
 		cout << "MC chi2: " << chi2 << " Ndf: " << ndf << endl;
 		cout << "Prob: " << TMath::Prob(chi2,ndf) << endl;

--- a/charmdet/MillepedeCaller.cxx
+++ b/charmdet/MillepedeCaller.cxx
@@ -437,7 +437,7 @@ double MillepedeCaller::MC_GBL_refit(unsigned int n_tracks)
 		tracks[i] = MC_gen_track();
 	}
 
-	cout << tracks.size() <<" track generated. Printing:" << endl;
+	cout << tracks.size() <<" tracks generated. Printing:" << endl;
 	for(auto track : tracks)
 	{
 		TVector3 pos = track[0];
@@ -703,6 +703,18 @@ vector<gbl::GblPoint> MillepedeCaller::MC_list_hits(const vector<TVector3>& mc_t
 	normal_distribution<double> gaussian_smear(0,350e-4); //mean 0, sigma 350um in cm
 
 	vector<pair<int,double>> hits = MC_gen_hits(mc_track_model[0], mc_track_model[1]);
+
+	cout << "Hits generated for track: " << endl;
+	TVector3 pos = mc_track_model[0];
+	TVector3 mom = mc_track_model[1];
+	cout << "(" << pos[0] << "," << pos[1] << "," << pos[2] << ") + ("
+			<< mom[0] << "," << mom[1] << "," << mom[2] << ")" << endl;
+	cout <<"MC hitlist:" << endl;
+	for(auto hit : hits)
+	{
+		cout << "ID = " << hit.first << " rt (unsmeared) = " << hit.second << endl;
+	}
+
 	vector<gbl::GblPoint> gbl_hits = {};
 
 	TMatrixD fit_system_base_vectors(2,3);
@@ -808,12 +820,7 @@ vector<pair<int,double>> MillepedeCaller::MC_gen_hits(const TVector3& start, con
 	//check distance to every tube
 	for(int id : m_tube_ids)
 	{
-		cout << "Decoding id" << id << endl;
 		MufluxSpectrometer::TubeEndPoints(id, wire_end_top, wire_end_bottom);
-		cout << "Top point: " << endl;
-		wire_end_top.Print();
-		cout << "Bottom point: " << endl;
-		wire_end_bottom.Print();
 		wire_to_track = calc_shortest_distance(wire_end_top, wire_end_bottom, start, direction, nullptr, nullptr);
 		if(wire_to_track.Mag() < 1.815)
 		{

--- a/charmdet/MillepedeCaller.cxx
+++ b/charmdet/MillepedeCaller.cxx
@@ -21,6 +21,7 @@ using namespace std;
 MillepedeCaller::MillepedeCaller(const char *outFileName, bool asBinary, bool writeZero)
 : mille(outFileName, asBinary, writeZero)
 {
+	m_mersenne_twister = mt19937();
 	m_gbl_mille_binary = new gbl::MilleBinary("debugging.mille_bin",true,2000);
 
 	m_tube_ids.resize(0);

--- a/charmdet/MillepedeCaller.cxx
+++ b/charmdet/MillepedeCaller.cxx
@@ -823,9 +823,9 @@ vector<pair<int,double>> MillepedeCaller::MC_gen_hits(const TVector3& start, con
 
 	//sort with lambda comparison
 	sort(result.begin(), result.end(), [&](pair<int,double> element1, pair<int,double> element2){
-		MufluxSpectrometer::TubeEndPoints(element1.second, wire_end_top, wire_end_bottom);
+		MufluxSpectrometer::TubeEndPoints(element1.first, wire_end_top, wire_end_bottom);
 		double z1 = (wire_end_bottom + ((wire_end_top - wire_end_bottom)* 0.5)).Z();
-		MufluxSpectrometer::TubeEndPoints(element2.second, wire_end_top, wire_end_bottom);
+		MufluxSpectrometer::TubeEndPoints(element2.first, wire_end_top, wire_end_bottom);
 		double z2 = (wire_end_bottom + ((wire_end_top - wire_end_bottom)* 0.5)).Z();
 		return z1 < z2;
 		});

--- a/charmdet/MillepedeCaller.cxx
+++ b/charmdet/MillepedeCaller.cxx
@@ -382,6 +382,16 @@ double MillepedeCaller::perform_GBL_refit(const genfit::Track& track) const
 		return -1;
 	}
 }
+double MillepedeCaller::MC_GBL_refit(unsigned int n_tracks) const
+{
+	vector<vector<TVector3>> tracks(n_tracks);
+	for(unsigned int i = 0; i < n_tracks; ++i)
+	{
+		tracks[i] = MC_gen_track();
+	}
+
+
+}
 
 //Reimplementation of python function
 /**
@@ -623,3 +633,19 @@ void MillepedeCaller::print_seed_hits(const genfit::Track& track) const
 }
 
 //TODO test projection matrix
+
+vector<gbl::GblPoint> MillepedeCaller::MC_list_hits(const vector<TVector3>& mc_track_model) const
+{
+	return {};
+}
+
+vector<TVector3> MillepedeCaller::MC_gen_track() const
+{
+	TRandom3 rng();
+	return {};
+}
+
+vector<pair<int,double>> MillepedeCaller::MC_gen_hits(const TVector3& start, const TVector3& direction) const
+{
+	return {};
+}

--- a/charmdet/MillepedeCaller.cxx
+++ b/charmdet/MillepedeCaller.cxx
@@ -427,7 +427,8 @@ double MillepedeCaller::perform_GBL_refit(const genfit::Track& track) const
 		return -1;
 	}
 }
-double MillepedeCaller::MC_GBL_refit(unsigned int n_tracks, double smearing_sigma, unsigned int min_hits = 3)
+
+double MillepedeCaller::MC_GBL_refit(unsigned int n_tracks, double smearing_sigma, unsigned int min_hits)
 {
 	double chi2, lostweight;
 	int ndf;

--- a/charmdet/MillepedeCaller.cxx
+++ b/charmdet/MillepedeCaller.cxx
@@ -19,7 +19,7 @@ using namespace std;
  * @param writeZero Flag that states if zero values should be kept or not
  */
 MillepedeCaller::MillepedeCaller(const char *outFileName, bool asBinary, bool writeZero)
-: mille(outFileName, asBinary, writeZero), m_mersenne_twister()
+: mille(outFileName, asBinary, writeZero)
 {
 	m_gbl_mille_binary = new gbl::MilleBinary("debugging.mille_bin",true,2000);
 

--- a/charmdet/MillepedeCaller.h
+++ b/charmdet/MillepedeCaller.h
@@ -52,7 +52,7 @@ public:
 					float sigma);
 
 	double perform_GBL_refit(const genfit::Track& track) const;
-	double MC_GBL_refit(unsigned int n_tracks);
+	double MC_GBL_refit(unsigned int n_tracks, double smearing_sigma);
 
 	ClassDef(MillepedeCaller,3);
 
@@ -103,7 +103,7 @@ private:
 	/*
 	 * Monte-Carlo Tracks for testing
 	 */
-	std::vector<gbl::GblPoint> MC_list_hits(const std::vector<TVector3>& mc_track_model, int event_id);
+	std::vector<gbl::GblPoint> MC_list_hits(const std::vector<TVector3>& mc_track_model, int event_id, double smearing_sigma);
 	std::vector<TVector3> MC_gen_track();
 	std::vector<std::pair<int,double>> MC_gen_hits(const TVector3& start, const TVector3& direction);
 	TMatrixD* calc_jacobian(const TVector3& PCA_1, const TVector3& PCA_2);

--- a/charmdet/MillepedeCaller.h
+++ b/charmdet/MillepedeCaller.h
@@ -40,7 +40,7 @@ class MillepedeCaller//: public TObject
 {
 public:
 	MillepedeCaller(const char *outFileName, bool asBinary = true, bool writeZero = false);
-	~MillepedeCaller();
+	virtual ~MillepedeCaller();
 
 	void call_mille(int n_local_derivatives,
 					const float *local_derivatives,
@@ -51,7 +51,7 @@ public:
 					float sigma);
 
 	double perform_GBL_refit(const genfit::Track& track) const;
-	double MC_GBL_refit(unsigned int n_tracks) const;
+	double MC_GBL_refit(unsigned int n_tracks);
 
 	ClassDef(MillepedeCaller,3);
 
@@ -102,10 +102,10 @@ private:
 	/*
 	 * Monte-Carlo Tracks for testing
 	 */
-	std::vector<gbl::GblPoint> MC_list_hits(const std::vector<TVector3>& mc_track_model) const;
-	std::vector<TVector3> MC_gen_track() const;
-	std::vector<std::pair<int,double>> MC_gen_hits(const TVector3& start, const TVector3& direction) const;
-	TMatrixD* calc_jacobian(const TVector3& PCA_1, const TVector3& PCA_2) const;
+	std::vector<gbl::GblPoint> MC_list_hits(const std::vector<TVector3>& mc_track_model);
+	std::vector<TVector3> MC_gen_track();
+	std::vector<std::pair<int,double>> MC_gen_hits(const TVector3& start, const TVector3& direction);
+	TMatrixD* calc_jacobian(const TVector3& PCA_1, const TVector3& PCA_2);
 
 };
 

--- a/charmdet/MillepedeCaller.h
+++ b/charmdet/MillepedeCaller.h
@@ -21,6 +21,7 @@
 
 //includes for MC testing
 #include <random>
+#include <fstream>
 
 typedef enum
 {
@@ -102,7 +103,7 @@ private:
 	/*
 	 * Monte-Carlo Tracks for testing
 	 */
-	std::vector<gbl::GblPoint> MC_list_hits(const std::vector<TVector3>& mc_track_model);
+	std::vector<gbl::GblPoint> MC_list_hits(const std::vector<TVector3>& mc_track_model, int event_id);
 	std::vector<TVector3> MC_gen_track();
 	std::vector<std::pair<int,double>> MC_gen_hits(const TVector3& start, const TVector3& direction);
 	TMatrixD* calc_jacobian(const TVector3& PCA_1, const TVector3& PCA_2);

--- a/charmdet/MillepedeCaller.h
+++ b/charmdet/MillepedeCaller.h
@@ -52,7 +52,7 @@ public:
 					float sigma);
 
 	double perform_GBL_refit(const genfit::Track& track) const;
-	double MC_GBL_refit(unsigned int n_tracks, double smearing_sigma);
+	double MC_GBL_refit(unsigned int n_tracks, double smearing_sigma, unsigned int min_hits = 3);
 
 	ClassDef(MillepedeCaller,3);
 
@@ -103,7 +103,7 @@ private:
 	/*
 	 * Monte-Carlo Tracks for testing
 	 */
-	std::vector<gbl::GblPoint> MC_list_hits(const std::vector<TVector3>& mc_track_model, int event_id, double smearing_sigma);
+	std::vector<gbl::GblPoint> MC_list_hits(const std::vector<TVector3>& mc_track_model, int event_id, double smearing_sigma, unsigned int min_hits);
 	std::vector<TVector3> MC_gen_track();
 	std::vector<std::pair<int,double>> MC_gen_hits(const TVector3& start, const TVector3& direction);
 	TMatrixD* calc_jacobian(const TVector3& PCA_1, const TVector3& PCA_2);

--- a/charmdet/MillepedeCaller.h
+++ b/charmdet/MillepedeCaller.h
@@ -20,7 +20,7 @@
 #include "MufluxSpectrometer.h"
 
 //includes for MC testing
-#include "TRandom3.h"
+#include <random>
 
 typedef enum
 {
@@ -58,6 +58,10 @@ public:
 private:
 	Mille mille;
 	gbl::MilleBinary* m_gbl_mille_binary;
+
+	//random generator
+	std::mt19937 m_mersenne_twister;
+	std::vector<int> m_tube_ids;
 
 	//helper methods
 	std::vector<gbl::GblPoint> list_hits(const genfit::Track* track) const;
@@ -101,6 +105,7 @@ private:
 	std::vector<gbl::GblPoint> MC_list_hits(const std::vector<TVector3>& mc_track_model) const;
 	std::vector<TVector3> MC_gen_track() const;
 	std::vector<std::pair<int,double>> MC_gen_hits(const TVector3& start, const TVector3& direction) const;
+	TMatrixD* calc_jacobian(const TVector3& PCA_1, const TVector3& PCA_2) const;
 
 };
 

--- a/charmdet/MillepedeCaller.h
+++ b/charmdet/MillepedeCaller.h
@@ -100,7 +100,7 @@ private:
 	 */
 	std::vector<gbl::GblPoint> MC_list_hits(const std::vector<TVector3>& mc_track_model) const;
 	std::vector<TVector3> MC_gen_track() const;
-	std::vector<std::pair<int,double>> MC_gen_hits(const TVector3& start, const TVector3& direction) const
+	std::vector<std::pair<int,double>> MC_gen_hits(const TVector3& start, const TVector3& direction) const;
 
 };
 

--- a/charmdet/MillepedeCaller.h
+++ b/charmdet/MillepedeCaller.h
@@ -19,6 +19,8 @@
 #include <cstdint>
 #include "MufluxSpectrometer.h"
 
+//includes for MC testing
+#include "TRandom3.h"
 
 typedef enum
 {
@@ -49,6 +51,7 @@ public:
 					float sigma);
 
 	double perform_GBL_refit(const genfit::Track& track) const;
+	double MC_GBL_refit(unsigned int n_tracks) const;
 
 	ClassDef(MillepedeCaller,3);
 
@@ -90,6 +93,14 @@ private:
 	 */
 	bool check_ordered_by_arclen(const genfit::Track& track) const;
 	void print_seed_hits(const genfit::Track& track) const;
+
+
+	/*
+	 * Monte-Carlo Tracks for testing
+	 */
+	std::vector<gbl::GblPoint> MC_list_hits(const std::vector<TVector3>& mc_track_model) const;
+	std::vector<TVector3> MC_gen_track() const;
+	std::vector<std::pair<int,double>> MC_gen_hits(const TVector3& start, const TVector3& direction) const
 
 };
 

--- a/charmdet/MufluxSpectrometer.h
+++ b/charmdet/MufluxSpectrometer.h
@@ -46,7 +46,7 @@ class MufluxSpectrometer:public FairDetector
     void SetTr34XDim(Double_t tr34xdim);   
     void SetMuonFlux(Bool_t muonflux);   
     static void TubeDecode(Int_t detID,int &statnb,int &vnb,int &pnb,int &lnb, int &snb);
-    void TubeEndPoints(Int_t detID, TVector3 &top, TVector3 &bot);
+    static void TubeEndPoints(Int_t detID, TVector3 &top, TVector3 &bot);
     void SetDistStereo(Double_t diststereoT1,Double_t diststereoT2);
     void SetDistT1T2(Double_t distT1T2);
     void SetDistT3T4(Double_t distT3T4);

--- a/charmdet/drifttubeMonitoring.py
+++ b/charmdet/drifttubeMonitoring.py
@@ -943,8 +943,16 @@ def print_layers(dt_modules_dict):
 
             angle = np.arctan(dx_top / dy_top)  * 180.0 / np.pi #angle w.r.t y axis
             print("CH: {}\t z = {}\t alpha = {}".format(tube._ID,centerpos[2],angle))
+            
+def print_modules(dt_modules_dict):
+    for key in dt_modules_dict.keys():
+        mod = dt_modules_dict[key]
+        print("Module: {}".format(key))
+        center = mod.get_center_position()
+        print("Centerpos = {}\t{}\t{}".format(center[0],center[1],center[2]))
                   
 print_layers(dt_modules)
+print_modules(dt_modules)
         
 
 def compareAlignment():

--- a/charmdet/drifttubeMonitoring.py
+++ b/charmdet/drifttubeMonitoring.py
@@ -28,8 +28,6 @@ MCdata = False
 # before RT correction: MCsmearing=0.04  #  + 0.027**2 -> 0.05  
 MCsmearing=0.022  #  + 0.027**2 -> 0.035
 
-milleCaller = ROOT.MillepedeCaller("test.milletest",True,True)
-milleCaller.MC_GBL_refit(100)
 ####### 
 cuts={}
 cuts['Ndf'] = 9
@@ -956,6 +954,9 @@ def print_modules(dt_modules_dict):
                   
 print_layers(dt_modules)
 print_modules(dt_modules)
+
+milleCaller = ROOT.MillepedeCaller("test.milletest",True,True)
+milleCaller.MC_GBL_refit(100)
         
 
 def compareAlignment():

--- a/charmdet/drifttubeMonitoring.py
+++ b/charmdet/drifttubeMonitoring.py
@@ -956,7 +956,7 @@ print_layers(dt_modules)
 print_modules(dt_modules)
 
 milleCaller = ROOT.MillepedeCaller("test.milletest",True,True)
-milleCaller.MC_GBL_refit(100000)
+milleCaller.MC_GBL_refit(1000)
         
 
 def compareAlignment():

--- a/charmdet/drifttubeMonitoring.py
+++ b/charmdet/drifttubeMonitoring.py
@@ -956,7 +956,7 @@ print_layers(dt_modules)
 print_modules(dt_modules)
 
 milleCaller = ROOT.MillepedeCaller("test.milletest",True,True)
-milleCaller.MC_GBL_refit(100)
+milleCaller.MC_GBL_refit(100000)
         
 
 def compareAlignment():

--- a/charmdet/drifttubeMonitoring.py
+++ b/charmdet/drifttubeMonitoring.py
@@ -956,7 +956,7 @@ print_layers(dt_modules)
 print_modules(dt_modules)
 
 milleCaller = ROOT.MillepedeCaller("test.milletest",True,True)
-milleCaller.MC_GBL_refit(1000)
+milleCaller.MC_GBL_refit(1000,350e-4)
         
 
 def compareAlignment():

--- a/charmdet/drifttubeMonitoring.py
+++ b/charmdet/drifttubeMonitoring.py
@@ -27,6 +27,9 @@ MCdata = False
 ########
 # before RT correction: MCsmearing=0.04  #  + 0.027**2 -> 0.05  
 MCsmearing=0.022  #  + 0.027**2 -> 0.035
+
+milleCaller = ROOT.MillepedeCaller("test.milletest",True,True)
+milleCaller.MC_GBL_refit(100)
 ####### 
 cuts={}
 cuts['Ndf'] = 9


### PR DESCRIPTION
# Description
Implemented a toy MC track generation for testing the fit.

# Results
The GBL fit seems to work fine for undisturbed, straight tracks. A number of 100,000 tracks was generated and the probability for the fit's chi2/ndf was analyzed. The distribution can be seen in the plot below:
![prob](https://user-images.githubusercontent.com/12298242/69430171-f813f100-0d2c-11ea-9fa8-3d09ab70b954.png)
This looks pretty promising, it has a mean of 0.499374300795572 +- 0.28796555803170665
