### PR TITLE
Globalsfix/refit/methods/dt alignment

### DIFF
--- a/charmdet/MillepedeCaller.cxx
+++ b/charmdet/MillepedeCaller.cxx
@@ -131,14 +131,16 @@ MillepedeCaller::~MillepedeCaller()
  * @brief List hits from seed track as vector<GblPoint>
  *
  * @author Stefan Bieschke
- * @date Aug. 06, 2019
- * @version 1.0
+ * @date Feb. 12, 2020
+ * @version 1.1
  *
  * @param track Seed track, in this case genfit::Track from Kalman fitter
+ * @param mode What structures should be aligned, can be MODULE or SINGLE_TUBE for example
+ * @param sigma_spatial spatial resolution guess for fit
  *
  * @return std::vector<gbl::GblPoint> containing the hits ordered by arclen with measurement added
  */
-vector<gbl::GblPoint> MillepedeCaller::list_hits(const genfit::Track* track, double sigma_spatial) const
+vector<gbl::GblPoint> MillepedeCaller::list_hits(const genfit::Track* track, const alignment_mode& mode, double sigma_spatial)
 {
 	vector<TVector3> linear_model = linear_model_wo_scatter(*track);
 	vector<gbl::GblPoint> result = {};
@@ -187,7 +189,23 @@ vector<gbl::GblPoint> MillepedeCaller::list_hits(const genfit::Track* track, dou
 		//calculate labels and global derivatives for hit
 		vector<int> label = labels(MODULE,det_id);
 		TVector3 wire_bot_to_top = vtop - vbot;
-		TMatrixD* globals = calc_global_parameters(PCA_track,linear_model,wire_bot_to_top);
+
+		TVector3 measurement_prediction, alignment_origin;
+		string module_descriptor;
+
+		switch (mode)
+		{
+		case MODULE:
+			module_descriptor = m_tube_id_to_module[det_id];
+			alignment_origin = calc_module_centerpos(make_pair(module_descriptor, m_modules[module_descriptor]));
+			measurement_prediction = PCA_track - alignment_origin;
+			break;
+		case SINGLE_TUBE:
+			alignment_origin = vbot + 0.5 * (vtop - vbot);
+			measurement_prediction = PCA_track - alignment_origin;
+			break;
+		}
+		TMatrixD* globals = calc_global_parameters(measurement_prediction,closest_approach,linear_model,wire_bot_to_top);
 		result.back().addGlobals(label, *globals);
 		delete globals;
 		delete jacobian;
@@ -300,13 +318,14 @@ vector<int> MillepedeCaller::labels_case_module(const int channel_id) const
  * @date Feb. 6, 2019
  * @version 1.1
  *
- * @param measurement_prediction predicted vector from the wire to the seed track in global reference frame
+ * @param measurement_prediction predicted vector from the alignment system origin to the closest approach on the track for this hit in global coordinates
+ * @param closest_approach vector of closest approach from wire to track in global reference frame
  * @param linear_model Linear track model with on-track coordinates and direction in global reference frame
  * @param Wire axis vector in global reference frame showing from wire bottom to wire top position
  *
  * @result Matrix (3x6) containing the derivatives of the measurement w.r.t all parameters
  */
-TMatrixD* MillepedeCaller::calc_global_parameters(const TVector3& measurement_prediction, const vector<TVector3>& linear_model, const TVector3& wire_bot_to_top) const
+TMatrixD* MillepedeCaller::calc_global_parameters(const TVector3& measurement_prediction, const TVector3& closest_approach, const vector<TVector3>& linear_model, const TVector3& wire_bot_to_top) const
 {
 	TRotation global_to_alignment;
 	global_to_alignment.SetYAxis(wire_bot_to_top);
@@ -315,7 +334,7 @@ TMatrixD* MillepedeCaller::calc_global_parameters(const TVector3& measurement_pr
 	TVector3 meas_prediction_in_alignment_system = global_to_alignment * measurement_prediction;
 	TVector3 track_dir_in_alignmentsys = global_to_alignment * linear_model[1];
 	TRotation global_to_measurement;
-	global_to_measurement.SetXAxis(measurement_prediction);
+	global_to_measurement.SetXAxis(closest_approach);
 	global_to_measurement.Invert();
 	TMatrixD mat_global_to_measurement = rot_to_matrix(global_to_measurement); //debugging
 
@@ -466,11 +485,11 @@ pair<double,TMatrixD*> MillepedeCaller::single_jacobian_with_arclength(const gen
 /**
  *
  */
-double MillepedeCaller::perform_GBL_refit(const genfit::Track& track, double sigma_spatial) const
+double MillepedeCaller::perform_GBL_refit(const genfit::Track& track, double sigma_spatial)
 {
 	try
 	{
-		vector < gbl::GblPoint > points = list_hits(&track, sigma_spatial);
+		vector < gbl::GblPoint > points = list_hits(&track, MODULE, sigma_spatial);
 		gbl::GblTrajectory traj(points,false); //param false for B=0
 
 		traj.milleOut(*m_gbl_mille_binary);
@@ -516,7 +535,7 @@ double MillepedeCaller::MC_GBL_refit(unsigned int n_tracks, double smearing_sigm
 	for(int i = 0; i < tracks.size(); ++i)
 	{
 		auto track = tracks[i];
-		vector<gbl::GblPoint> hitlist = MC_list_hits(track,smearing_sigma,min_hits);
+		vector<gbl::GblPoint> hitlist = MC_list_hits(track,MODULE,smearing_sigma,min_hits);
 		if(hitlist.size() < min_hits)
 		{
 			continue;
@@ -927,7 +946,7 @@ void MillepedeCaller::print_fitted_track(gbl::GblTrajectory& trajectory) const
  *
  * @return std::vector<gbl::GblPoint> containing all hits, except track has less than @c min_hits hits, then it will be empty
  */
-vector<gbl::GblPoint> MillepedeCaller::MC_list_hits(const vector<TVector3>& mc_track_model, double smearing_sigma, unsigned int min_hits)
+vector<gbl::GblPoint> MillepedeCaller::MC_list_hits(const vector<TVector3>& mc_track_model, const alignment_mode& mode, double smearing_sigma, unsigned int min_hits)
 {
 	//apply gaussian smearing of measured hit
 	normal_distribution<double> gaussian_smear(0,smearing_sigma); //mean 0, sigma 350um in cm
@@ -977,8 +996,23 @@ vector<gbl::GblPoint> MillepedeCaller::MC_list_hits(const vector<TVector3>& mc_t
 	//add labels and derivatives for first hit
 	vector<int> label = labels(MODULE,hits[0].first);
 	TVector3 wire_bot_to_top = vtop - vbot;
-	TVector3 measurement_prediction; //TODO implement
-	TMatrixD* globals = calc_global_parameters(closest_approach,mc_track_model,wire_bot_to_top);
+	TVector3 measurement_prediction, alignment_origin;//TODO implement
+	string module_descriptor;
+
+	switch(mode)
+	{
+	case MODULE:
+		module_descriptor = m_tube_id_to_module[hits[0].first];
+		alignment_origin = calc_module_centerpos(make_pair(module_descriptor, m_modules[module_descriptor]));
+		measurement_prediction = PCA_track - alignment_origin;
+		break;
+	case SINGLE_TUBE:
+		alignment_origin = vbot + 0.5 * (vtop - vbot);
+		measurement_prediction = PCA_track - alignment_origin;
+		break;
+	}
+
+	TMatrixD* globals = calc_global_parameters(measurement_prediction,closest_approach,mc_track_model,wire_bot_to_top);
 	gbl_hits.back().addGlobals(label, *globals);
 	delete globals;
 
@@ -1009,8 +1043,20 @@ vector<gbl::GblPoint> MillepedeCaller::MC_list_hits(const vector<TVector3>& mc_t
 		//calculate labels and global derivatives for hit
 		vector<int> label = labels(MODULE,hits[i].first);
 		wire_bot_to_top = vtop - vbot;
-		TVector3 measurement_prediction; //TODO implement
-		TMatrixD* globals = calc_global_parameters(closest_approach,mc_track_model,wire_bot_to_top);
+
+		switch(mode)
+		{
+		case MODULE:
+			module_descriptor = m_tube_id_to_module[hits[0].first];
+			alignment_origin = calc_module_centerpos(make_pair(module_descriptor, m_modules[module_descriptor]));
+			measurement_prediction = PCA_track - alignment_origin;
+			break;
+		case SINGLE_TUBE:
+			alignment_origin = vbot + 0.5 * (vtop - vbot);
+			measurement_prediction = PCA_track - alignment_origin;
+			break;
+		}
+		TMatrixD* globals = calc_global_parameters(measurement_prediction,closest_approach,mc_track_model,wire_bot_to_top);
 		gbl_hits.back().addGlobals(label, *globals);
 		delete globals;
 	}
@@ -1099,8 +1145,9 @@ vector<pair<int,double>> MillepedeCaller::MC_gen_hits(const TVector3& start, con
 	TVector3 wire_to_track;
 
 	//check distance to every tube
-	for(int id : m_tube_ids)
+	for(auto entry : m_tube_id_to_module)
 	{
+		int id = entry.first;
 		MufluxSpectrometer::TubeEndPoints(id, wire_end_top, wire_end_bottom);
 		if(shifted_det_ids)
 		{

--- a/charmdet/MillepedeCaller.cxx
+++ b/charmdet/MillepedeCaller.cxx
@@ -41,17 +41,29 @@ MillepedeCaller::MillepedeCaller(const char* out_file_name)
 
 	//generate list of tube ids
 	//T1 and T2
+	string module_name;
 	for (char station = 1; station < 3; ++station)
 	{
 		for (char view = 0; view < 2; ++view)
 		{
+			switch (station)
+			{
+			case 1:
+				module_name = view == 0 ? "T1X" : "T1U";
+				break;
+			case 2:
+				module_name = view == 0 ? "T2V" : "T2X";
+				break;
+			}
 			for (char plane = 0; plane < 2; ++plane)
 			{
 				for (char layer = 0; layer < 2; ++layer)
 				{
 					for (char tube = 1; tube < 13; ++tube)
 					{
-						m_tube_ids.push_back(station*10000000+view*1000000+plane*100000+layer*10000+2000+tube);
+						int id = station * 10000000 + view * 1000000 + plane * 100000 + layer * 10000 + 2000 + tube;
+						m_tube_ids.push_back(id);
+						m_modules[module_name].push_back(id);
 					}
 				}
 			}
@@ -94,38 +106,6 @@ MillepedeCaller::MillepedeCaller(const char* out_file_name)
 			}
 		}
 	}
-	vector<int> t1x = {};
-	int station = 1;
-	int view = 0;
-	for (char plane = 0; plane < 2; ++plane)
-	{
-		for (char layer = 0; layer < 2; ++layer)
-		{
-			for (char tube = 1; tube < 13; ++tube)
-			{
-				t1x.push_back(station * 10000000 + view * 1000000 + plane * 100000
-								+ layer * 10000 + 2000 + tube);
-			}
-		}
-	}
-
-	m_modules["T1X"] = t1x;
-	vector<int> t1u = {};
-	station = 1;
-	view = 1;
-	for (char plane = 0; plane < 2; ++plane)
-	{
-		for (char layer = 0; layer < 2; ++layer)
-		{
-			for (char tube = 1; tube < 13; ++tube)
-			{
-				t1x.push_back(
-						station * 10000000 + view * 1000000 + plane * 100000
-								+ layer * 10000 + 2000 + tube);
-			}
-		}
-	}
-	m_modules["T1U"] = t1u;
 }
 
 
@@ -963,6 +943,7 @@ vector<gbl::GblPoint> MillepedeCaller::MC_list_hits(const vector<TVector3>& mc_t
 	//add labels and derivatives for first hit
 	vector<int> label = labels(MODULE,hits[0].first);
 	TVector3 wire_bot_to_top = vtop - vbot;
+	TVector3 measurement_prediction; //TODO implement
 	TMatrixD* globals = calc_global_parameters(closest_approach,mc_track_model,wire_bot_to_top);
 	gbl_hits.back().addGlobals(label, *globals);
 	delete globals;
@@ -994,6 +975,7 @@ vector<gbl::GblPoint> MillepedeCaller::MC_list_hits(const vector<TVector3>& mc_t
 		//calculate labels and global derivatives for hit
 		vector<int> label = labels(MODULE,hits[i].first);
 		wire_bot_to_top = vtop - vbot;
+		TVector3 measurement_prediction; //TODO implement
 		TMatrixD* globals = calc_global_parameters(closest_approach,mc_track_model,wire_bot_to_top);
 		gbl_hits.back().addGlobals(label, *globals);
 		delete globals;

--- a/charmdet/MillepedeCaller.h
+++ b/charmdet/MillepedeCaller.h
@@ -45,7 +45,7 @@ public:
 	MillepedeCaller(const char* out_file_name);
 	virtual ~MillepedeCaller();
 
-	double perform_GBL_refit(const genfit::Track& track, double sigma_spatial) const;
+	double perform_GBL_refit(const genfit::Track& track, double sigma_spatial);
 	double MC_GBL_refit(unsigned int n_tracks, double smearing_sigma, unsigned int min_hits = 3);
 	void write_resolution_function(const char* filename, const genfit::Track& track, std::vector<MufluxSpectrometerHit>* raw_hits = nullptr) const;
 
@@ -61,7 +61,7 @@ private:
 	std::unordered_map<std::string,TVector3> m_nominal_module_centerpos; //nominal geometric center of a drift tube module
 
 	//helper methods
-	std::vector<gbl::GblPoint> list_hits(const genfit::Track* track, double sigma_spatial) const;
+	std::vector<gbl::GblPoint> list_hits(const genfit::Track* track, const alignment_mode& mode, double sigma_spatial);
 	void add_measurement_info(gbl::GblPoint& point, const TVector3& closest_approach, const double measurement, const double sigma_spatial) const;
 	/*
 	 * Helpers for jacobian calculation
@@ -89,7 +89,7 @@ private:
 	 */
 	std::vector<int> labels(const alignment_mode mode, const int channel_id) const;
 	std::vector<int> labels_case_module(const int channel_id) const;
-	TMatrixD* calc_global_parameters(const TVector3& measurement_prediction, const std::vector<TVector3>& linear_model, const TVector3& wire_bot_to_top) const;
+	TMatrixD* calc_global_parameters(const TVector3& measurement_prediction, const TVector3& closest_approach, const std::vector<TVector3>& linear_model, const TVector3& wire_bot_to_top) const;
 
 
 	/*
@@ -104,7 +104,7 @@ private:
 	/*
 	 * Monte-Carlo Tracks for testing
 	 */
-	std::vector<gbl::GblPoint> MC_list_hits(const std::vector<TVector3>& mc_track_model, double smearing_sigma, unsigned int min_hits);
+	std::vector<gbl::GblPoint> MC_list_hits(const std::vector<TVector3>& mc_track_model, const alignment_mode& mode, double smearing_sigma, unsigned int min_hits);
 	std::vector<TVector3> MC_gen_track();
 	std::vector<std::pair<int,double>> MC_gen_hits(const TVector3& start, const TVector3& direction, const std::vector<int>* shifted_det_ids = nullptr);
 	TMatrixD* calc_jacobian(const TVector3& PCA_1, const TVector3& PCA_2) const;

--- a/charmdet/MillepedeCaller.h
+++ b/charmdet/MillepedeCaller.h
@@ -57,7 +57,8 @@ private:
 	//random generator
 	std::mt19937 m_mersenne_twister;
 	std::vector<int> m_tube_ids;
-	std::unordered_map<std::string, std::vector<int>> m_modules;
+	std::unordered_map<std::string, std::vector<int>> m_modules; //detector IDs making up a module
+	std::unordered_map<std::string,TVector3> m_nominal_module_centerpos; //nominal geometric center of a drift tube module
 
 	//helper methods
 	std::vector<gbl::GblPoint> list_hits(const genfit::Track* track, double sigma_spatial) const;

--- a/charmdet/MillepedeCaller.h
+++ b/charmdet/MillepedeCaller.h
@@ -56,7 +56,7 @@ private:
 
 	//random generator
 	std::mt19937 m_mersenne_twister;
-	std::vector<int> m_tube_ids;
+	std::unordered_map<int,std::string> m_tube_id_to_module;
 	std::unordered_map<std::string, std::vector<int>> m_modules; //detector IDs making up a module
 	std::unordered_map<std::string,TVector3> m_nominal_module_centerpos; //nominal geometric center of a drift tube module
 
@@ -76,6 +76,7 @@ private:
 	TRotation calc_rotation_of_vector(const TVector3& v) const;
 	TMatrixD rot_to_matrix(const TRotation& rot) const;
 	TMatrixD calc_projection_matrix(const TMatrixD& fit_system_base_vectors, const TMatrixD& rotation_global_to_measurement) const;
+	TVector3 calc_module_centerpos(const std::pair<std::string,std::vector<int>>& module_name_id_list_pair) const;
 
 	/*
 	 * GBL model methods

--- a/charmdet/drifttubeMonitoring.py
+++ b/charmdet/drifttubeMonitoring.py
@@ -8118,7 +8118,7 @@ elif options.command == "test":
     yep.stop()
     print "finished"
 elif options.command == "GBL_MC":
-    n_mc_tracks = int(1e5)
+    n_mc_tracks = int(1e1)
     n_min_hits = 3 #Minimum number of hits (total)
     filename = "GBL_MC_" + str(n_mc_tracks) + "_tracks.mille_bin"
     milleCaller = ROOT.MillepedeCaller(filename)

--- a/charmdet/drifttubeMonitoring.py
+++ b/charmdet/drifttubeMonitoring.py
@@ -7996,7 +7996,7 @@ def GBL_refit(nEvent=-1,nTot=1000,PR=13,minP=10.):
                 refit
                 """
                 print("Processing event number {}".format(Nr))
-                chi2_gbl = milleCaller.perform_GBL_refit(aTrack,6*0.05)              
+                chi2_gbl = milleCaller.perform_GBL_refit(aTrack,3*0.05)              
                 if(chi2_gbl == -1):
                     aborted_gbl_refits += 1
                 else:
@@ -8118,7 +8118,7 @@ elif options.command == "test":
     yep.stop()
     print "finished"
 elif options.command == "GBL_MC":
-    n_mc_tracks = int(1e1)
+    n_mc_tracks = int(1e5)
     n_min_hits = 3 #Minimum number of hits (total)
     filename = "GBL_MC_" + str(n_mc_tracks) + "_tracks.mille_bin"
     milleCaller = ROOT.MillepedeCaller(filename)


### PR DESCRIPTION
# Description
In the prior version, there was an error in the calculation of the global derivatives used for pede alignment. Before, each hit had an own alignment system with its origin in the point of closest approach on the sense wire. Now, each alignable structure (e.g. a drift tube module) has a common alignment reference frame with the origin in its geometric center position.